### PR TITLE
Use fetch with retries when getting items

### DIFF
--- a/craftprofit.py
+++ b/craftprofit.py
@@ -123,12 +123,13 @@ def main():
         gw2.api.API_KEY = f.read().strip()
     gw2.api.CACHE_DIR = 'cache'
 
+    print("Fetching account materials")
     materials = fetch('/v2/account/materials', cache=True)
     material_counts = {}
     for m in materials:
         material_counts[m['id']] = m['count']
 
-
+    print("Fetching recipes")
     all_items = set()
     for r in gw2.recipes.iter_all():
         if can_craft(r):
@@ -136,8 +137,10 @@ def main():
                 all_items.add(i['item_id'])
             all_items.add(r['output_item_id'])
 
+    print("Fetching items")
     gw2.items.get_multi(all_items)
 
+    print("Fetching trading post prices")
     buy_prices = {}
     sell_prices = {}
     for x in gw2.trading_post.get_prices_multi(all_items):

--- a/gw2/api.py
+++ b/gw2/api.py
@@ -2,6 +2,7 @@ import json
 import os
 import requests
 import sys
+import time
 
 API_BASE = 'https://api.guildwars2.com'
 API_KEY = None
@@ -30,3 +31,18 @@ def fetch(path, cache=False):
             json.dump(j, f)
 
     return j
+
+def fetch_with_retries(path, retry_count=3, seconds_between_retries=2, cache=False):
+    retries=0
+    while retries < retry_count:
+        try:
+            response = fetch(path, cache)
+            break
+        except requests.HTTPError as e:
+            retries += 1
+            time.sleep(seconds_between_retries)
+            print('Error fetching path. Retry: ', retries)
+    if retries >= retry_count:
+        raise Exception('FetchWithRetryFailure')
+
+    return response

--- a/gw2/items.py
+++ b/gw2/items.py
@@ -2,10 +2,8 @@ from collections import defaultdict
 import functools
 import json
 import os
-import requests
-import time
 
-from gw2.api import fetch
+from gw2.api import fetch, fetch_with_retries
 from gw2.constants import STORAGE_DIR
 import gw2.build
 from gw2.util import DataStorage
@@ -41,11 +39,11 @@ def _refresh():
 
     by_name = {}
 
-    pos = 0
     N = 100
     for i in range(0, len(all_ids), N):
         chunk = all_ids[i : i + N]
-        items = fetch('/v2/items?ids=' + ','.join(str(i) for i in chunk))
+        items = fetch_with_retries('/v2/items?ids=' + ','.join(str(i) for i in chunk), retry_count=20)
+        
         for i in items:
             data.add(i['id'], i)
             by_name[i['name']] = i['id']

--- a/gw2/recipes.py
+++ b/gw2/recipes.py
@@ -2,8 +2,6 @@ from collections import defaultdict
 import functools
 import json
 import os
-import requests
-import time
 
 from gw2.api import fetch
 from gw2.constants import STORAGE_DIR


### PR DESCRIPTION
I noticed that the items API will randomly 404 for any given chunk of items fetched. This was true even in a browser. So this adds sleep if any http error is returned and retries a fetch. This can be used for other resources if we need them down the road.